### PR TITLE
A draft implementation of 4 functions for periodic boundaries

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -204,6 +204,13 @@ namespace TriaAccessorExceptions
    * @ingroup Exceptions
    */
   DeclException0 (ExcFacesHaveNoLevel);
+  /**
+   * Your are trying to get the periodic neighbor for a face, which does not
+   * have a periodic neighbor. For more information on this, refer to
+   * @ref GlossPeriodicConstraints "entry for periodic boundaries".
+   * @ingroup Exceptions
+   */
+  DeclException0 (ExcNoPeriodicNeighbor);
 //TODO: Write documentation!
   /**
    * @ingroup Exceptions
@@ -2535,29 +2542,68 @@ public:
   unsigned int neighbor_face_no (const unsigned int neighbor) const;
 
   /**
-   * If the cell has a periodic neighbor at the given face, this function
-   * returns true, otherwise, the returned value is false. This function
-   * is valid for locally owned cells and ghost cells. For artificial cells,
-   * we do not store the periodicity data.
+   * @}
+   */
+  /**
+   * @name Dealing with periodic neighbor
+   */
+  /**
+   * @{
+   */
+   /**
+   * If the cell has a periodic neighbor at its @c ith face, this function
+   * returns true, otherwise, the returned value is false.
    */
   bool has_periodic_neighbor(const unsigned int i) const;
 
   /**
-   * For the locally owned cells or ghost cells in the triangulation, which
-   * have a face on a periodic boundary
+   * For a cell which has its @c ith face, on a periodic boundary
    * (see @ref GlossPeriodicConstraints "the entry for periodic baoundaries")
-   * this function returns an iterator to the cell on the other side of the
-   * periodic boundary. Otherwise (i.e. the cell is artificial or not located
-   * next to a periodic boundary) this function returns the
-   * same cell iterator as @c neighbor() does. Similar to @c neighbor()
-   * function, the returned cell has at most the same level of refinement
-   * as the current cell. On distributed meshes, by calling
-   * Triangulation::add_periodicity(), one can make sure that the element
-   * on the other side of the periodic boundary exists in this rank as a
-   * ghost cell or a locally owned cell.
+   * this function returns an iterator to the cell on the other side
+   * of the periodic face. Otherwise, invalid iterator will be returned.
+   * In order to check if a cell has periodic neighbor on its @c ith face
+   * or not, one should first call @c has_periodic_neighbor() function.
+   * Similar to @c neighbor(), the returned cell
+   * has at most the same level of refinement as the current cell.
+   * On distributed meshes, by calling Triangulation::add_periodicity(),
+   * one can make sure that the element on the other side of the periodic
+   * boundary exists in this rank as a ghost cell or a locally owned cell.
    */
-  TriaIterator<CellAccessor<dim, spacedim>  >
-  neighbor_or_periodic_neighbor (const unsigned int i) const;
+  TriaIterator<CellAccessor<dim, spacedim> >
+  periodic_neighbor (const unsigned int i) const;
+
+  /**
+   *
+   */
+  TriaIterator<CellAccessor<dim, spacedim> >
+  periodic_neighbor_child_on_subface (const unsigned int face_no,
+                                      const unsigned int subface_no) const;
+
+  /**
+   *
+   */
+  std::pair<unsigned int, unsigned int>
+  periodic_neighbor_of_coarser_periodic_neighbor (const unsigned i) const;
+
+  /**
+   * This function returns the index of the periodic neighbor. If there is
+   * no periodic neighbor at the given face, the return value is -1.
+   */
+  int
+  periodic_neighbor_index (const unsigned int i) const;
+
+   /**
+   * This function returns the level of the periodic neighbor. If there is
+   * no periodic neighbor at the given face, the return value is -1.
+   */
+  int
+  periodic_neighbor_level (const unsigned int i) const;
+
+  /**
+   *
+   */
+  unsigned int
+  periodic_neighbor_of_periodic_neighbor (const unsigned int i) const;
 
   /**
    * If a cell has periodic neighbor, this function returns the face number
@@ -2574,16 +2620,6 @@ public:
    */
   bool
   periodic_neighbor_is_coarser (const unsigned int i) const;
-
-  /**
-   * This function returns true if the element on the other side of the
-   * periodic boundary is refined on the common periodic face with the
-   * current element. Otherwise, it returns false. The implementation
-   * allows this function to work, in the case of anisotropic
-   * refinement.
-   */
-  bool
-  periodic_neighbor_is_refined (const unsigned int i) const;
 
   /**
    * @}

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -2535,6 +2535,57 @@ public:
   unsigned int neighbor_face_no (const unsigned int neighbor) const;
 
   /**
+   * If the cell has a periodic neighbor at the given face, this function
+   * returns true, otherwise, the returned value is false. This function
+   * is valid for locally owned cells and ghost cells. For artificial cells,
+   * we do not store the periodicity data.
+   */
+  bool has_periodic_neighbor(const unsigned int i) const;
+
+  /**
+   * For the locally owned cells or ghost cells in the triangulation, which
+   * have a face on a periodic boundary
+   * (see @ref GlossPeriodicConstraints "the entry for periodic baoundaries")
+   * this function returns an iterator to the cell on the other side of the
+   * periodic boundary. Otherwise (i.e. the cell is artificial or not located
+   * next to a periodic boundary) this function returns the
+   * same cell iterator as @c neighbor() does. Similar to @c neighbor()
+   * function, the returned cell has at most the same level of refinement
+   * as the current cell. On distributed meshes, by calling
+   * Triangulation::add_periodicity(), one can make sure that the element
+   * on the other side of the periodic boundary exists in this rank as a
+   * ghost cell or a locally owned cell.
+   */
+  TriaIterator<CellAccessor<dim, spacedim>  >
+  neighbor_or_periodic_neighbor (const unsigned int i) const;
+
+  /**
+   * If a cell has periodic neighbor, this function returns the face number
+   * of the neighbor, which is connected to this cell.
+   */
+  unsigned int
+  periodic_neighbor_face_no (const unsigned int i) const;
+
+  /**
+   * This function returns true if the element on the other side of the
+   * periodic boundary is coarser and returns false, otherwise. The
+   * implementation allows this function to work, in the case of
+   * anisotropic refinement.
+   */
+  bool
+  periodic_neighbor_is_coarser (const unsigned int i) const;
+
+  /**
+   * This function returns true if the element on the other side of the
+   * periodic boundary is refined on the common periodic face with the
+   * current element. Otherwise, it returns false. The implementation
+   * allows this function to work, in the case of anisotropic
+   * refinement.
+   */
+  bool
+  periodic_neighbor_is_refined (const unsigned int i) const;
+
+  /**
    * @}
    */
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1872,8 +1872,30 @@ template <int dim, int spacedim>
 bool
 CellAccessor<dim, spacedim>::has_periodic_neighbor (const unsigned int i_face) const
 {
+  /*
+   * Implementation note: In all of the functions corresponding to periodic faces
+   * we mainly use the Triangulation::periodic_face_map to find the
+   * information about periodically connected faces. So, we actually search in
+   * this std::map and return the cell_face on the other side of periodic boundary.
+   * For this search process, we have three options:
+   *
+   * 1- Using the [] operator of std::map: This option results in a more readalbe
+   *    code, but requires an extra iteration in the map. Becasue when we call [] on
+   *    std::map, with a key which does not exist in the std::map, that key will be
+   *    created and the default value will be returned by []. This is not desirable.
+   *    So, one has to first check if the key exists in the std::map and if it exists,
+   *    then use the [] operator. The existence check is possible using std::map::find()
+   *    or std::map::count(). Using this option will result in two iteration cycles
+   *    through the map. First, existence check, then returning the value.
+   *
+   * 2- Using std::map::find(): This option is less readble, but theoretically
+   *    faster. Because, it results in one iteration through std::map object.
+   *
+   * We decided to use the 2nd option.
+   */
+  AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
   typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
-  /* my_it : is the iterator to the current cell. */
+  // my_it : is the iterator to the current cell.
   cell_iterator my_it(*this);
   if (this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face))
       != this->tria->periodic_face_map.end())
@@ -1886,26 +1908,180 @@ CellAccessor<dim, spacedim>::has_periodic_neighbor (const unsigned int i_face) c
 template <int dim, int spacedim>
 TriaIterator<CellAccessor<dim,spacedim> >
 CellAccessor<dim, spacedim>::
-neighbor_or_periodic_neighbor (const unsigned int i_face) const
+periodic_neighbor (const unsigned int i_face) const
 {
-  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
-  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
-  /* my_it        : the iterator to the current cell.
+  /*
+   * To know, why we are using std::map::find() instead of [] operator, refer
+   * to the implementation note in has_periodic_neighbor() function.
+   *
+   * my_it        : the iterator to the current cell.
    * my_face_pair : the pair reported by periodic_face_map as its first pair being
    *                the current cell_face.
    */
+  AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
+  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
+  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
+  typedef std::pair<cell_face_pair, std::bitset<3>> oriented_cell_face_pair;
   cell_iterator my_it(*this);
-  typename std::map<const cell_face_pair, cell_face_pair>::const_iterator my_face_pair =
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator my_face_pair =
     this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face));
-  if (my_face_pair != this->tria->periodic_face_map.end())
-  {
-    /*
-     * Some assertions might be required !
-     */
-    return my_face_pair->second.first;
-  }
-  else
-    return neighbor(i_face);
+  // Assertion is required to check that we are actually on a periodic boundary.
+  Assert (my_face_pair != this->tria->periodic_face_map.end(),
+         TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  return my_face_pair->second.first.first;
+}
+
+
+
+template <int dim, int spacedim>
+TriaIterator<CellAccessor<dim, spacedim> >
+CellAccessor<dim, spacedim>::
+periodic_neighbor_child_on_subface (const unsigned int i_face,
+                                    const unsigned int i_subface) const
+{
+  /*
+   * To know, why we are using std::map::find() instead of [] operator, refer
+   * to the implementation note in has_periodic_neighbor() function.
+   *
+   * my_it            : the iterator to the current cell.
+   * my_face_pair     : the pair reported by periodic_face_map as its first pair being
+   *                    the current cell_face.
+   * nb_it            : the iterator to the neighbor of current cell at i_face.
+   * face_num_of_nb   : the face number of the periodically neighboring face in the
+   *                    relevant element.
+   * nb_parent_face_it: the iterator to the parent face of the periodically
+   *                    neighboring face.
+   */
+  AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
+  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
+  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
+  typedef std::pair<cell_face_pair, std::bitset<3>> oriented_cell_face_pair;
+  cell_iterator my_it(*this);
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator my_face_pair =
+    this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face));
+  /*
+   * There should be an assertion, which tells the user that this function should not be
+   * used for a cell which is not located at a periodic boundary.
+   */
+  Assert (my_face_pair != this->tria->periodic_face_map.end(),
+          TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  cell_iterator parent_nb_it = my_face_pair->second.first.first;
+  unsigned int nb_face_num = my_face_pair->second.first.second;
+  TriaIterator<TriaAccessor<dim - 1, dim, spacedim>> nb_parent_face_it =
+    parent_nb_it->face(nb_face_num);
+  /*
+   * We should check if the parent face of the neighbor has at least the same number of
+   * children as i_subface.
+   */
+  AssertIndexRange (i_subface, nb_parent_face_it->n_children());
+  unsigned int sub_neighbor_num =
+    GeometryInfo<dim>::child_cell_on_face(parent_nb_it->refinement_case(),
+                                          nb_face_num,
+                                          i_subface,
+                                          my_face_pair->second.second[0],
+                                          my_face_pair->second.second[1],
+                                          my_face_pair->second.second[2],
+                                          nb_parent_face_it->refinement_case());
+  return parent_nb_it->child(sub_neighbor_num);
+}
+
+
+
+template <int dim, int spacedim>
+std::pair<unsigned int, unsigned int>
+CellAccessor<dim, spacedim>::
+periodic_neighbor_of_coarser_periodic_neighbor (const unsigned int i_face) const
+{
+  /*
+   * To know, why we are using std::map::find() instead of [] operator, refer
+   * to the implementation note in has_periodic_neighbor() function.
+   *
+   * my_it        : the iterator to the current cell.
+   * my_face_pair : the pair reported by periodic_face_map as its first pair being
+   *                the current cell_face.
+   * nb_it        : the iterator to the periodic neighbor.
+   * nb_face_pair : the pair reported by periodic_face_map as its first pair being
+   *                the periodic neighbor cell_face.
+   * p_nb_of_p_nb : the iterator of the periodic neighbor of the periodic neighbor
+   *                of the current cell.
+   */
+  AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
+  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
+  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
+  typedef std::pair<cell_face_pair, std::bitset<3>> oriented_cell_face_pair;
+  const unsigned int my_face_index = this->face_index(i_face);
+  cell_iterator my_it(*this);
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator my_face_pair =
+    this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face));
+  /*
+   * There should be an assertion, which tells the user that this function should not be
+   * used for a cell which is not located at a periodic boundary.
+   */
+  Assert (my_face_pair != this->tria->periodic_face_map.end(),
+          TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  cell_iterator nb_it = my_face_pair->second.first.first;
+  unsigned int face_num_of_nb = my_face_pair->second.first.second;
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator nb_face_pair =
+    this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(nb_it, face_num_of_nb));
+  /*
+   * Since, we store periodic neighbors for every cell (either active or artificial or inactive)
+   * the nb_face_pair should also be mapped to some cell_face pair. We assert this here.
+   */
+  Assert (nb_face_pair != this->tria->periodic_face_map.end(),
+          TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  cell_iterator p_nb_of_p_nb = nb_face_pair->second.first.first;
+  TriaIterator<TriaAccessor<dim - 1, dim, spacedim>> parent_face_it =
+    p_nb_of_p_nb->face(nb_face_pair->second.first.second);
+  for (unsigned int i_subface = 0; i_subface < parent_face_it->n_children(); ++i_subface)
+    if (parent_face_it->child_index(i_subface) == my_face_index)
+      return (std::pair<unsigned int, unsigned int>(face_num_of_nb, i_subface));
+  /*
+   * Obviously, if the execution reaches to this point, some of our assumptions should have
+   * been false. The most important one is, the user has called this funciton on a face
+   * which does not have a coarser periodic neighbor.
+   */
+  Assert (false, TriaAccessorExceptions::ExcNeighborIsNotCoarser());
+  return std::pair<unsigned int, unsigned int>(numbers::invalid_unsigned_int,
+                                               numbers::invalid_unsigned_int);
+}
+
+
+
+template <int dim, int spacedim>
+int CellAccessor<dim, spacedim>::
+periodic_neighbor_index(const unsigned int i_face) const
+{
+  AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
+  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
+  /* my_it : is the iterator to the current cell. */
+  cell_iterator my_it(*this);
+  assert (this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face))
+         != this->tria->periodic_face_map.end());
+  return my_it->index();
+}
+
+
+
+template <int dim, int spacedim>
+int CellAccessor<dim, spacedim>::
+periodic_neighbor_level(const unsigned int i_face) const
+{
+  AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
+  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
+  /* my_it : is the iterator to the current cell. */
+  cell_iterator my_it(*this);
+  assert (this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face))
+          != this->tria->periodic_face_map.end());
+  return my_it->level();
+}
+
+
+
+template <int dim, int spacedim>
+unsigned int CellAccessor<dim, spacedim>::
+periodic_neighbor_of_periodic_neighbor(const unsigned int i_face) const
+{
+  return periodic_neighbor_face_no(i_face);
 }
 
 
@@ -1914,21 +2090,28 @@ template <int dim, int spacedim>
 unsigned int
 CellAccessor<dim, spacedim>::periodic_neighbor_face_no (const unsigned int i_face) const
 {
-  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
-  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
-  /* my_it        : the iterator to the current cell.
+  /*
+   * To know, why we are using std::map::find() instead of [] operator, refer
+   * to the implementation note in has_periodic_neighbor() function.
+   *
+   * my_it        : the iterator to the current cell.
    * my_face_pair : the pair reported by periodic_face_map as its first pair being
    *                the current cell_face.
    */
+  AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
+  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
+  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
+  typedef std::pair<cell_face_pair, std::bitset<3>> oriented_cell_face_pair;
   cell_iterator my_it(*this);
-  typename std::map<const cell_face_pair, cell_face_pair>::const_iterator my_face_pair =
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator my_face_pair =
     this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face));
   /*
    * There should be an assertion, which tells the user that this function should not be
    * called for a cell which is not located at a periodic boundary !
    */
-  assert(my_face_pair != this->tria->periodic_face_map.end());
-  return my_face_pair->second.second;
+  Assert (my_face_pair != this->tria->periodic_face_map.end(),
+          TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  return my_face_pair->second.first.second;
 }
 
 
@@ -1937,69 +2120,47 @@ template <int dim, int spacedim>
 bool
 CellAccessor<dim, spacedim>::periodic_neighbor_is_coarser (const unsigned int i_face) const
 {
-  /* Implementation note: Let p_nb_of_p_nb be the periodic neighbor of the periodic
+  /*
+   * To know, why we are using std::map::find() instead of [] operator, refer
+   * to the implementation note in has_periodic_neighbor() function.
+   *
+   * Implementation note: Let p_nb_of_p_nb be the periodic neighbor of the periodic
    * neighbor of the current cell. Also, let p_face_of_p_nb_of_p_nb be the periodic
    * face of the p_nb_of_p_nb. If p_face_of_p_nb_of_p_nb has children , then the
    * periodic neighbor of the current cell is coarser than itself. Although not tested,
-   * this implementation should work for anisotropic refinement as well. */
-  typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
-  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
-  /* my_it        : the iterator to the current cell.
+   * this implementation should work for anisotropic refinement as well.
+   *
+   * my_it        : the iterator to the current cell.
    * my_face_pair : the pair reported by periodic_face_map as its first pair being
    *                the current cell_face.
    * nb_it        : the iterator to the periodic neighbor.
    * nb_face_pair : the pair reported by periodic_face_map as its first pair being
    *                the periodic neighbor cell_face.
    */
-  cell_iterator my_it(*this);
-  typename std::map<const cell_face_pair, cell_face_pair>::const_iterator my_face_pair =
-    this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face));
-  /*
-   * There should be an assertion, which tells the user that this function should not be
-   * used for a cell which is not located at a periodic boundary ! Also, an assertion is
-   * required to check if the cell is active.
-   */
-  assert((this->active()) && !(this->is_artificial()));
-  assert(my_face_pair != this->tria->periodic_face_map.end());
-  cell_iterator nb_it = my_face_pair->second.first;
-  unsigned int face_num_of_nb = my_face_pair->second.second;
-  typename std::map<const cell_face_pair, cell_face_pair>::const_iterator nb_face_pair =
-    this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(nb_it, face_num_of_nb));
-  /*
-   * If the periodic neighbor is not mapped to any other periodic cell_face pair, then
-   * it is not active cell, and should have children. So the active cell on the other
-   * side of the periodic boundary is not coarser.
-   */
-  if (nb_face_pair == this->tria->periodic_face_map.end())
-    return false;
-  else if (nb_face_pair->second.first->face(nb_face_pair->second.second)->has_children())
-    return true;
-  return false;
-}
-
-
-
-template <int dim, int spacedim>
-bool
-CellAccessor<dim, spacedim>::periodic_neighbor_is_refined (const unsigned int i_face) const
-{
+  AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
   typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
   typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
-  /* my_it        : the iterator to the current cell.
-   * my_face_pair : the pair reported by periodic_face_map as its first pair being
-   *                the current cell_face.
-   */
+  typedef std::pair<cell_face_pair, std::bitset<3>> oriented_cell_face_pair;
   cell_iterator my_it(*this);
-  typename std::map<const cell_face_pair, cell_face_pair>::const_iterator my_face_pair =
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator my_face_pair =
     this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face));
   /*
    * There should be an assertion, which tells the user that this function should not be
-   * used for a cell which is not located at a periodic boundary ! Also, an assertion is
-   * required to check if the cell is active.
+   * used for a cell which is not located at a periodic boundary.
    */
-  assert((this->active()) && !(this->is_artificial()));
-  assert(my_face_pair != this->tria->periodic_face_map.end());
-  if (my_face_pair->second.first->face(my_face_pair->second.second)->has_children())
+  Assert (my_face_pair != this->tria->periodic_face_map.end(),
+          TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  cell_iterator nb_it = my_face_pair->second.first.first;
+  unsigned int face_num_of_nb = my_face_pair->second.first.second;
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator nb_face_pair =
+    this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(nb_it, face_num_of_nb));
+  /*
+   * Since, we store periodic neighbors for every cell (either active or artificial or inactive)
+   * the nb_face_pair should also be mapped to some cell_face pair. We assert this here.
+   */
+  Assert (nb_face_pair != this->tria->periodic_face_map.end(),
+         TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  if (nb_face_pair->second.first.first->face(nb_face_pair->second.first.second)->has_children())
     return true;
   return false;
 }

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2051,13 +2051,24 @@ template <int dim, int spacedim>
 int CellAccessor<dim, spacedim>::
 periodic_neighbor_index(const unsigned int i_face) const
 {
+  /*
+   * To know, why we are using std::map::find() instead of [] operator, refer
+   * to the implementation note in has_periodic_neighbor() function.
+   *
+   * my_it        : the iterator to the current cell.
+   * my_face_pair : the pair reported by periodic_face_map as its first pair being
+   *                the current cell_face.
+   */
   AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
   typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
-  /* my_it : is the iterator to the current cell. */
+  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
+  typedef std::pair<cell_face_pair, std::bitset<3>> oriented_cell_face_pair;
   cell_iterator my_it(*this);
-  assert (this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face))
-         != this->tria->periodic_face_map.end());
-  return my_it->index();
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator my_face_pair =
+    this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face));
+  Assert (my_face_pair != this->tria->periodic_face_map.end(),
+          TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  return my_face_pair->second.first.first->index();
 }
 
 
@@ -2066,13 +2077,24 @@ template <int dim, int spacedim>
 int CellAccessor<dim, spacedim>::
 periodic_neighbor_level(const unsigned int i_face) const
 {
+  /*
+   * To know, why we are using std::map::find() instead of [] operator, refer
+   * to the implementation note in has_periodic_neighbor() function.
+   *
+   * my_it        : the iterator to the current cell.
+   * my_face_pair : the pair reported by periodic_face_map as its first pair being
+   *                the current cell_face.
+   */
   AssertIndexRange (i_face, GeometryInfo<dim>::faces_per_cell);
   typedef TriaIterator<CellAccessor<dim, spacedim>> cell_iterator;
-  /* my_it : is the iterator to the current cell. */
+  typedef std::pair<cell_iterator, unsigned int> cell_face_pair;
+  typedef std::pair<cell_face_pair, std::bitset<3>> oriented_cell_face_pair;
   cell_iterator my_it(*this);
-  assert (this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face))
-          != this->tria->periodic_face_map.end());
-  return my_it->level();
+  typename std::map<const cell_face_pair, oriented_cell_face_pair>::const_iterator my_face_pair =
+    this->tria->periodic_face_map.find(std::pair<cell_iterator, unsigned int>(my_it, i_face));
+  Assert (my_face_pair != this->tria->periodic_face_map.end(),
+          TriaAccessorExceptions::ExcNoPeriodicNeighbor());
+  return my_face_pair->second.first.first->level();
 }
 
 

--- a/tests/mpi/triangulation_periodicity/test_1/CMakeLists.txt
+++ b/tests/mpi/triangulation_periodicity/test_1/CMakeLists.txt
@@ -1,0 +1,52 @@
+##
+#  CMake script for the step-45 tutorial program:
+##
+
+# Set the name of the project and target:
+SET(TARGET "test_1")
+
+# Declare all source files the target consists of. Here, this is only
+# the one step-X.cc file, but as you expand your project you may wish
+# to add other source files as well. If your project becomes much larger,
+# you may want to either replace the following statement by something like
+#  FILE(GLOB_RECURSE TARGET_SRC  "source/*.cc")
+#  FILE(GLOB_RECURSE TARGET_INC  "include/*.h")
+#  SET(TARGET_SRC ${TARGET_SRC}  ${TARGET_INC})
+# or switch altogether to the large project CMakeLists.txt file discussed
+# in the "CMake in user projects" page accessible from the "User info"
+# page of the documentation.
+SET(TARGET_SRC
+  ${TARGET}.cc
+  )
+
+# Usually, you will not need to modify anything beyond this point...
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8)
+
+FIND_PACKAGE(deal.II 8.5.0 QUIET
+  HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
+  )
+IF(NOT ${deal.II_FOUND})
+  MESSAGE(FATAL_ERROR "\n"
+    "*** Could not locate a (sufficiently recent) version of deal.II. ***\n\n"
+    "You may want to either pass a flag -DDEAL_II_DIR=/path/to/deal.II to cmake\n"
+    "or set an environment variable \"DEAL_II_DIR\" that contains this path."
+    )
+ENDIF()
+
+#
+# Are all dependencies fulfilled?
+#
+IF( NOT DEAL_II_WITH_MPI OR
+    NOT DEAL_II_WITH_P4EST)
+  MESSAGE(FATAL_ERROR "
+Error! The deal.II library found at ${DEAL_II_PATH} was not configured with
+    DEAL_II_WITH_MPI = ON
+    DEAL_II_WITH_P4EST = ON
+One or all of these are OFF in your installation but are required for this tutorial step."
+    )
+ENDIF()
+
+DEAL_II_INITIALIZE_CACHED_VARIABLES()
+PROJECT(${TARGET})
+DEAL_II_INVOKE_AUTOPILOT()

--- a/tests/mpi/triangulation_periodicity/test_1/test_1.cc
+++ b/tests/mpi/triangulation_periodicity/test_1/test_1.cc
@@ -1,0 +1,243 @@
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_boundary_lib.h>
+#include <deal.II/grid/tria_iterator.h>
+#include <deal.II/lac/vector.h>
+
+#include <fstream>
+#include <string>
+
+/*
+ * Test objectives:
+ *
+ * 1. To control if periodic faces have at most one level of refinement
+ *    difference.
+ *
+ * 2. To test the following functions:
+ *    - cell->has_periodic_neighbor(i_face)
+ *    - cell->neighbor_or_periodic_neighbor(i_face)
+ *    - cell->periodic_neighbor_is_coarser(i_face)
+ *    - cell->periodic_neighbor_is_refined(i_face)
+ *
+ * We start with a 4x4 mesh and refine a single element twice, to get the
+ * following mesh:
+ *
+ *
+ *                      Top periodic boundary
+ *       -------------------------------------------------
+ *       |           |     |  |  |     |     |           |
+ *       |           |     |-----|     |     |           |
+ *       |           |     |  |  |     |     |           |
+ *       |           -------------------------           |
+ *       |           |     |     |     |     |           |
+ *       |           |     |     |     |     |           |
+ *       |           |     |     |     |     |           |
+ *       -------------------------------------------------
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       -------------------------------------------------
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       |           |           |           |           |
+ *       -------------------------------------------------
+ *       |           |     |     |     |     |           |
+ *       |           |     |     |     |     |           |
+ *       |           |     |     |     |     |           |
+ *       |           -------------------------           |
+ *       |           |     |     |     |     |           |
+ *       |           |     |     |     |     |           |
+ *       |           |     |     |     |     |           |
+ *       -------------------------------------------------
+ *                    Bottom periodic boundary
+ */
+
+using namespace dealii;
+
+template <int dim>
+struct periodicity_tests
+{
+  typedef TriaIterator<CellAccessor<dim>> cell_iterator;
+  periodicity_tests();
+  ~periodicity_tests();
+
+  unsigned refn_cycle;
+  MPI_Comm mpi_comm;
+  int comm_rank, comm_size;
+  parallel::distributed::Triangulation<dim> the_grid;
+
+  void refine_grid(const int &);
+  void write_grid();
+  void check_periodicity();
+};
+
+template <int dim>
+periodicity_tests<dim>::periodicity_tests()
+  : refn_cycle(0), mpi_comm(MPI_COMM_WORLD), the_grid(mpi_comm)
+{
+  assert(dim == 2 || dim == 3);
+  comm_rank = Utilities::MPI::this_mpi_process(mpi_comm);
+  comm_size = Utilities::MPI::n_mpi_processes(mpi_comm);
+  std::vector<unsigned> repeats(dim, 2);
+  Point<dim> p1, p2;
+  if (dim == 2)
+    p2 = { 16., 16. };
+  if (dim == 3)
+    p2 = { 16., 16., 16. };
+  GridGenerator::subdivided_hyper_rectangle(the_grid, repeats, p1, p2, true);
+  std::vector<GridTools::PeriodicFacePair<cell_iterator>> periodic_faces;
+  GridTools::collect_periodic_faces(
+    the_grid, 2, 3, 0, periodic_faces, Tensor<1, dim>({ 0., 16. }));
+  the_grid.add_periodicity(periodic_faces);
+}
+
+template <int dim>
+void periodicity_tests<dim>::refine_grid(const int &n = 1)
+{
+  if (n != 0 && refn_cycle == 0)
+  {
+    the_grid.refine_global(n);
+    refn_cycle += n;
+  }
+  else if (n != 0)
+  {
+    Point<dim> refn_point;
+    if (dim == 2)
+      refn_point = { 6.5, 15.5 };
+    if (dim == 3)
+      refn_point = { 6.5, 6.5, 15.5 };
+    for (unsigned i_refn = 0; i_refn < n; ++i_refn)
+    {
+      for (cell_iterator &&cell_it : the_grid.active_cell_iterators())
+      {
+        if (cell_it->is_locally_owned() && cell_it->point_inside(refn_point))
+        {
+          cell_it->set_refine_flag();
+          break;
+        }
+      }
+      the_grid.execute_coarsening_and_refinement();
+      ++refn_cycle;
+    }
+  }
+}
+
+template <int dim>
+void periodicity_tests<dim>::write_grid()
+{
+  GridOut Grid1_Out;
+  GridOutFlags::Svg svg_flags(
+    1,                                       // line_thickness = 2,
+    2,                                       // boundary_line_thickness = 4,
+    false,                                   // margin = true,
+    dealii::GridOutFlags::Svg::transparent,  // background = white,
+    0,                                       // azimuth_angle = 0,
+    0,                                       // polar_angle = 0,
+    dealii::GridOutFlags::Svg::subdomain_id, // coloring = level_number,
+    false, // convert_level_number_to_height = false,
+    false, // label_level_number = true,
+    true,  // label_cell_index = true,
+    false, // label_material_id = false,
+    false, // label_subdomain_id = false,
+    true,  // draw_colorbar = true,
+    true); // draw_legend = true
+  Grid1_Out.set_flags(svg_flags);
+  if (dim == 2)
+  {
+    std::ofstream Grid1_OutFile("Grid1" + std::to_string(refn_cycle) +
+                                std::to_string(comm_rank) + ".svg");
+    Grid1_Out.write_svg(the_grid, Grid1_OutFile);
+  }
+  else
+  {
+    std::ofstream Grid1_OutFile("Grid1" + std::to_string(refn_cycle) +
+                                std::to_string(comm_rank) + ".msh");
+    Grid1_Out.write_msh(the_grid, Grid1_OutFile);
+  }
+}
+
+template <int dim>
+void periodicity_tests<dim>::check_periodicity()
+{
+  typedef std::pair<cell_iterator, unsigned> cell_face_pair;
+  typedef typename std::map<cell_face_pair, cell_face_pair>::iterator cell_face_map_it;
+
+  for (int rank_i = 0; rank_i < comm_size; ++rank_i)
+  {
+    if (comm_rank == rank_i)
+    {
+      std::cout << "All of the cells with periodic neighbors on rank "
+                << comm_rank << std::endl;
+      for (const cell_iterator &cell_it : the_grid.active_cell_iterators())
+      {
+        for (unsigned i_face = 0; i_face < GeometryInfo<dim>::faces_per_cell; ++i_face)
+        {
+          if (cell_it->has_periodic_neighbor(i_face))
+          {
+            const cell_iterator &nb_it =
+              cell_it->neighbor_or_periodic_neighbor(i_face);
+            unsigned i_nb_face = cell_it->periodic_neighbor_face_no(i_face);
+            std::cout << cell_it->face(i_face)->center()
+                      << " is a periodic neighbor of "
+                      << nb_it->face(i_nb_face)->center();
+            if (cell_it->periodic_neighbor_is_coarser(i_face))
+              std::cout << ". And periodic neighbor is coarser." << std::endl;
+            else if (cell_it->periodic_neighbor_is_refined(i_face))
+              std::cout << ". And periodic neighbor is finer." << std::endl;
+            else
+              std::cout << ". And periodic neighbor has the same level." << std::endl;
+          }
+        }
+      }
+    }
+    MPI_Barrier(mpi_comm);
+  }
+}
+
+template <int dim>
+periodicity_tests<dim>::~periodicity_tests()
+{
+}
+
+int main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  periodicity_tests<2> test1;
+  /* Let us first check the periodicity of the simple case of uniformly refined
+   * mesh.
+   */
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    std::cout
+      << "First, we check the periodic faces on a uniformly refined mesh."
+      << std::endl;
+  test1.refine_grid(1);
+  test1.write_grid();
+  test1.check_periodicity();
+
+  /* Next, we want to check the case of nonuniform mesh */
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    std::cout
+      << "Next, we check the periodic faces on an adaptively refined mesh."
+      << std::endl;
+  test1.refine_grid(2);
+  test1.write_grid();
+  test1.check_periodicity();
+
+
+  return 0;
+}


### PR DESCRIPTION
The following functions are implemented:

- cell->has_periodic_neighbor
- cell->neighbor_or_periodic_neighbor
- cell->periodic_neighbor_is_coarser
- cell->periodic_neighbor_is_refined

The relevant documentation is also added to the header file. Some assertions with appropriate exception handling is required to be added later. Instead of Assert(), currently I have just used assert(). A new test is also added for a mesh with periodic boundary, and the above four functions seem to work, for both parallel and sequential runs.
